### PR TITLE
Add innerRef prop to Popper component

### DIFF
--- a/src/Popper.js
+++ b/src/Popper.js
@@ -34,6 +34,7 @@ type PopperProps = {
   positionFixed?: boolean,
   referenceElement?: ReferenceElement,
   children: RenderProp,
+  innerRef?: (?HTMLElement) => mixed,
 };
 
 type PopperState = {
@@ -68,7 +69,12 @@ export class InnerPopper extends Component<PopperProps, PopperState> {
     data: undefined,
   };
 
-  setPopperNode = (popperNode: ?HTMLElement) => this.setState({ popperNode });
+  setPopperNode = (popperNode: ?HTMLElement) => {
+    if (this.props.innerRef) {
+      this.props.innerRef(popperNode);
+    }
+    this.setState({ popperNode });
+  };
   setArrowNode = (arrowNode: ?HTMLElement) => this.setState({ arrowNode });
 
   updateStateModifier = {


### PR DESCRIPTION
Would resolve https://github.com/FezVrasta/react-popper/issues/140

Not sure if there was a reason this was removed in v1 , but figured I'd put a PR up to add it back since it was easy.