### PR TITLE
fix placement type in PopperProps.children

### DIFF
--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -21,7 +21,7 @@ interface PopperProps {
   children: (props: ({
     ref: (ref: HTMLElement | null) => void,
     style: React.CSSProperties,
-    placement: ?PopperJS.Placement,
+    placement?: PopperJS.Placement,
     outOfBoundaries: boolean | null,
     scheduleUpdate: () => void,
     arrowProps: {

--- a/typings/tests/tsconfig.json
+++ b/typings/tests/tsconfig.json
@@ -5,7 +5,6 @@
     "jsx": "react",
     "noEmit": true,
     "strict": true,
-    "skipLibCheck": true,
     "moduleResolution": "node",
     "typeRoots": ["./node_modules/@types"],
     "types": ["react"]


### PR DESCRIPTION
type is `undefined  | PopperJS.Placement`, not `?PopperJS.Placement` since that doesn't mean anything in typescript and was probably copied from Flow

fixes error that I get in typescript compiler:

```
node_modules/react-popper/typings/react-popper.d.ts
(24,16): JSDoc types can only be used inside documentation comments.
```