### PR TITLE
more interfaces in typescript typings

### DIFF
--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -2,32 +2,35 @@ import * as React from "react";
 import * as PopperJS from "popper.js";
 
 interface ManagerProps {
-  children: React.ReactNode;
+    children: React.ReactNode;
 }
 export class Manager extends React.Component<ManagerProps, {}> { }
 
+interface RefProps {
+    ref: (ref: HTMLElement | null) => void;
+}
+
 interface ReferenceProps {
-  children: (props: ({
-    ref: (ref: HTMLElement | null) => void,
-  })) => React.ReactNode;
+    children: (props: RefProps) => React.ReactNode;
 }
 export class Reference extends React.Component<ReferenceProps, {}> { }
 
+interface ArrowProps extends RefProps {
+    style: React.CSSProperties;
+}
+
+interface PopperChildrenProps extends RefProps {
+    arrowProps: ArrowProps
+    placement: PopperJS.Placement;
+    scheduleUpdate: () => void;
+    style: React.CSSProperties;
+}
+
 interface PopperProps {
-  modifiers?: PopperJS.Modifiers;
-  placement?: PopperJS.Placement;
-  eventsEnabled?: boolean;
-  positionFixed?: boolean;
-  children: (props: ({
-    ref: (ref: HTMLElement | null) => void,
-    style: React.CSSProperties,
-    placement: ?PopperJS.Placement,
-    outOfBoundaries: boolean | null,
-    scheduleUpdate: () => void,
-    arrowProps: {
-      ref: (ref: HTMLElement | null) => void,
-      style: React.CSSProperties,
-    },
-  })) => React.ReactNode;
+    children: (props: PopperChildrenProps) => React.ReactNode;
+    eventsEnabled?: boolean;
+    modifiers?: PopperJS.Modifiers;
+    placement?: PopperJS.Placement;
+    positionFixed?: boolean;
 }
 export class Popper extends React.Component<PopperProps, {}> { }

--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -25,7 +25,7 @@ interface PopperArrowProps {
 interface PopperChildrenProps {
   arrowProps: PopperArrowProps;
   outOfBoundaries: boolean | null;
-  placement?: PopperJS.Placement;
+  placement: PopperJS.Placement;
   ref: RefHandler;
   scheduleUpdate: () => void;
   style: React.CSSProperties;

--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -20,7 +20,8 @@ interface ArrowProps extends RefProps {
 }
 
 interface PopperChildrenProps extends RefProps {
-    arrowProps: ArrowProps
+    arrowProps: ArrowProps;
+    outOfBoundaries: boolean | null;
     placement: PopperJS.Placement;
     scheduleUpdate: () => void;
     style: React.CSSProperties;

--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -2,36 +2,40 @@ import * as React from "react";
 import * as PopperJS from "popper.js";
 
 interface ManagerProps {
-    children: React.ReactNode;
+  children: React.ReactNode;
 }
 export class Manager extends React.Component<ManagerProps, {}> { }
 
-interface RefProps {
-    ref: (ref: HTMLElement | null) => void;
+type RefHandler = (ref: HTMLElement | null) => void;
+
+interface ReferenceChildrenProps {
+  ref: RefHandler;
 }
 
 interface ReferenceProps {
-    children: (props: RefProps) => React.ReactNode;
+  children: (props: ReferenceChildrenProps) => React.ReactNode;
 }
 export class Reference extends React.Component<ReferenceProps, {}> { }
 
-interface ArrowProps extends RefProps {
-    style: React.CSSProperties;
+interface PopperArrowProps {
+  ref: RefHandler;
+  style: React.CSSProperties;
 }
 
-interface PopperChildrenProps extends RefProps {
-    arrowProps: ArrowProps;
-    outOfBoundaries: boolean | null;
-    placement: PopperJS.Placement;
-    scheduleUpdate: () => void;
-    style: React.CSSProperties;
+interface PopperChildrenProps {
+  arrowProps: PopperArrowProps;
+  outOfBoundaries: boolean | null;
+  placement: PopperJS.Placement;
+  ref: RefHandler;
+  scheduleUpdate: () => void;
+  style: React.CSSProperties;
 }
 
 interface PopperProps {
-    children: (props: PopperChildrenProps) => React.ReactNode;
-    eventsEnabled?: boolean;
-    modifiers?: PopperJS.Modifiers;
-    placement?: PopperJS.Placement;
-    positionFixed?: boolean;
+  children: (props: PopperChildrenProps) => React.ReactNode;
+  eventsEnabled?: boolean;
+  modifiers?: PopperJS.Modifiers;
+  placement?: PopperJS.Placement;
+  positionFixed?: boolean;
 }
 export class Popper extends React.Component<PopperProps, {}> { }

--- a/typings/tests/tsconfig.json
+++ b/typings/tests/tsconfig.json
@@ -5,7 +5,6 @@
     "jsx": "react",
     "noEmit": true,
     "strict": true,
-    "skipLibCheck": true,
     "moduleResolution": "node",
     "typeRoots": ["./node_modules/@types"],
     "types": ["react"]


### PR DESCRIPTION
#### fixes #152 

split typescript types into more interfaces that can be used separately in app code

```tsx
import * as React from "react";
import { Manager, Popper, PopperChildrenProps, Reference, RefProps } from "react-popper";

export class Component extends React.Component {
    public render() {
        return <Manager><Popper>{this.renderPopper}</Popper></Manager>;
    }
    private renderPopper = (props: PopperChildrenProps) => {
        // profit! reuse the same function instance!
    }
}