### PR TITLE
fix: Ensure "external-helpers" only included in Rollup builds. Fixes #1595

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,6 @@
     "react"
   ],
   "plugins": [
-    "external-helpers",
     "transform-class-properties"
   ],
   "env": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,13 @@ const baseConfig = (outputFormat) => {
     input: 'src/index.js',
     plugins: [
       nodeResolve(),
-      babel(),
+      babel({
+        plugins: [
+          // Ensure "external-helpers" is only included in rollup builds
+          // Issue: https://github.com/rollup/rollup/issues/1595
+          'external-helpers',
+        ],
+      }),
       replace({
         'process.env.NODE_ENV': JSON.stringify('production')
       }),


### PR DESCRIPTION
Confirmed `./lib/Manager.js` version built matches v0.10.1 and `/dist/*` matches v0.10.2

Fixes #160 

/cc @TrySound 