### PR TITLE
add Popper & Reference innerRef prop

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/index.umd.js": {
-    "bundled": 51326,
-    "minified": 18445,
-    "gzipped": 5908
+    "bundled": 51290,
+    "minified": 18413,
+    "gzipped": 5897
   },
   "dist/index.umd.min.js": {
-    "bundled": 28128,
-    "minified": 10794,
-    "gzipped": 3612
+    "bundled": 28092,
+    "minified": 10762,
+    "gzipped": 3602
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/index.umd.js": {
-    "bundled": 49520,
-    "minified": 17625,
-    "gzipped": 5759
+    "bundled": 51326,
+    "minified": 18445,
+    "gzipped": 5908
   },
   "dist/index.umd.min.js": {
-    "bundled": 26322,
-    "minified": 9974,
-    "gzipped": 3427
+    "bundled": 28128,
+    "minified": 10794,
+    "gzipped": 3612
   }
 }

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -9,7 +9,7 @@ import PopperJS, {
 } from 'popper.js';
 import type { Style } from 'typed-styles';
 import { ManagerContext } from './Manager';
-import { unwrapArray } from './utils';
+import { safeInvoke, unwrapArray } from './utils';
 
 type getRefFn = (?HTMLElement) => void;
 type ReferenceElement = ReferenceObject | HTMLElement | null;
@@ -31,12 +31,13 @@ export type PopperChildrenProps = {|
 export type PopperChildren = PopperChildrenProps => React.Node;
 
 export type PopperProps = {
+  children: PopperChildren,
+  eventsEnabled?: boolean,
+  innerRef?: getRefFn,
   modifiers?: Modifiers,
   placement?: Placement,
-  eventsEnabled?: boolean,
   positionFixed?: boolean,
   referenceElement?: ReferenceElement,
-  children: PopperChildren,
 };
 
 type PopperState = {
@@ -71,7 +72,10 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
     data: undefined,
   };
 
-  setPopperNode = (popperNode: ?HTMLElement) => this.setState({ popperNode });
+  setPopperNode = (popperNode: ?HTMLElement) => {
+    safeInvoke(this.props.innerRef, popperNode);
+    this.setState({ popperNode });
+  }
   setArrowNode = (arrowNode: ?HTMLElement) => this.setState({ arrowNode });
 
   updateStateModifier = {

--- a/src/Reference.js
+++ b/src/Reference.js
@@ -10,7 +10,11 @@ export type ReferenceProps = {
   innerRef?: (?HTMLElement) => void,
 };
 
-export class InnerReference extends React.Component<ReferenceProps> {
+type InnerReferenceProps = {
+  getReferenceRef?: (?HTMLElement) => void,
+}
+
+class InnerReference extends React.Component<ReferenceProps & InnerReferenceProps> {
   refHandler = (node: ?HTMLElement) => {
     safeInvoke(this.props.innerRef, node);
     safeInvoke(this.props.getReferenceRef, node);

--- a/src/__snapshots__/Reference.test.js.snap
+++ b/src/__snapshots__/Reference.test.js.snap
@@ -17,7 +17,19 @@ exports[`Arrow component renders the expected markup 1`] = `
 >
   <Reference>
     <Consumer>
-      <div />
+      <InnerReference
+        getReferenceRef={
+          [MockFunction] {
+            "calls": Array [
+              Array [
+                <div />,
+              ],
+            ],
+          }
+        }
+      >
+        <div />
+      </InnerReference>
     </Consumer>
   </Reference>
 </Provider>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,17 @@
 // @flow
 
-// Takes an argument and if it's an array, returns the first item in the array,
-// otherwise returns the argument. Used for Preact compatibility.
+/**
+ * Takes an argument and if it's an array, returns the first item in the array,
+ * otherwise returns the argument. Used for Preact compatibility.
+ */
 export const unwrapArray = (arg: *): * => (Array.isArray(arg) ? arg[0] : arg);
+
+/**
+ * Takes a maybe-undefined function and arbitrary args and invokes the function
+ * only if it is defined.
+ */
+export const safeInvoke = (fn: ?Function, ...args: *) => {
+  if (typeof fn === "function") {
+    return fn(...args);
+  }
+}

--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -14,6 +14,7 @@ interface ReferenceChildrenProps {
 
 interface ReferenceProps {
   children: (props: ReferenceChildrenProps) => React.ReactNode;
+  innerRef?: RefHandler;
 }
 export class Reference extends React.Component<ReferenceProps, {}> { }
 
@@ -34,6 +35,7 @@ interface PopperChildrenProps {
 interface PopperProps {
   children: (props: PopperChildrenProps) => React.ReactNode;
   eventsEnabled?: boolean;
+  innerRef?: RefHandler;
   modifiers?: PopperJS.Modifiers;
   placement?: PopperJS.Placement;
   positionFixed?: boolean;


### PR DESCRIPTION
#### Fixes #140 

tested this in Blueprint's `Popover` locally (via `yarn link`) and was able to get it rendering _without_ the infinite loop!

@FezVrasta this was my first experience with Flow and I must say it was rather subpar compared to TypeScript. Why did you choose to use Flow for this project and would you consider migrating to TypeScript? (I'd be happy to do the conversion, it'll take like an hour.)