### PR TITLE
Replace es name with esm

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
     "test": {
       "presets": ["env", "stage-1", "react"]
     },
-    "es": {
+    "esm": {
       "presets": [["env", { "modules": false }], "stage-1", "react"]
     },
     "cjs": {

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/index.umd.js": {
-    "bundled": 51290,
-    "minified": 18413,
-    "gzipped": 5897
+    "bundled": 51215,
+    "minified": 18354,
+    "gzipped": 5879
   },
   "dist/index.umd.min.js": {
-    "bundled": 28092,
-    "minified": 10762,
-    "gzipped": 3602
+    "bundled": 28017,
+    "minified": 10703,
+    "gzipped": 3585
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Travis Arnold <travis@souporserious.com> (http://souporserious.com)",
   "homepage": "https://github.com/souporserious/react-popper",
   "main": "lib/cjs/index.js",
-  "module": "lib/es/index.js",
+  "module": "lib/esm/index.js",
   "typings": "typings/react-popper.d.ts",
   "files": [
     "/dist",
@@ -14,10 +14,10 @@
     "/typings/react-popper.d.ts"
   ],
   "scripts": {
-    "build": "npm run build:clean && npm run build:es && npm run build:cjs && npm run build:umd && npm run build:flow",
+    "build": "npm run build:clean && npm run build:esm && npm run build:cjs && npm run build:umd && npm run build:flow",
     "build:clean": "rimraf dist/ && rimraf lib/",
     "build:umd": "rollup -c",
-    "build:es": "cross-env BABEL_ENV=es babel src --ignore '*.test.js,__mocks__' --out-dir lib/es",
+    "build:esm": "cross-env BABEL_ENV=esm babel src --ignore '*.test.js,__mocks__' --out-dir lib/esm",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --ignore '*.test.js,__mocks__' --out-dir lib/cjs",
     "build:flow": "flow-copy-source --ignore '{__mocks__/*,*.test}.js' src lib/cjs",
     "demo:dev": "parcel --out-dir demo/dist demo/index.html",


### PR DESCRIPTION
`esm` is more descriptive name for distribution es modules and used by
[esm loader](https://github.com/standard-things/esm) (it's not webpack loader) and rollup [started migrating to it](https://github.com/rollup/rollup/blob/master/CHANGELOG.md#0590)

Also `es` is used in material-ui for distribution es6+ code.