### PR TITLE
perf: reduce renders by moving values off of PopperState

### DIFF
--- a/src/Popper.js
+++ b/src/Popper.js
@@ -41,7 +41,6 @@ export type PopperProps = {
 };
 
 type PopperState = {
-  popperInstance: ?PopperJS$Instance,
   data: ?Data,
 };
 
@@ -64,9 +63,10 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
   };
 
   state = {
-    popperInstance: undefined,
     data: undefined,
   };
+
+  popperInstance: ?PopperJS$Instance;
 
   popperNode: ?HTMLElement = null;
   arrowNode: ?HTMLElement = null;
@@ -130,9 +130,8 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
     this.state.data ? this.state.data.hide : undefined;
 
   initPopperInstance = () => {
-    const { popperNode} = this
+    const { popperNode, popperInstance } = this
     const { referenceElement } = this.props;
-    const { popperInstance } = this.state;
 
     if (referenceElement && popperNode && !popperInstance) {
       const popperInstance = new PopperJS(
@@ -140,28 +139,31 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
         popperNode,
         this.getOptions()
       );
-      this.setState({ popperInstance });
+      this.popperInstance = popperInstance;
       return true;
     }
     return false;
   };
 
-  destroyPopperInstance = (callback: () => boolean) => {
-    if (this.state.popperInstance) {
-      this.state.popperInstance.destroy();
-    }
-    this.setState({ popperInstance: undefined }, callback);
+  destroy = () => {
+    if (!this.popperInstance) return false
+    this.popperInstance.destroy();
+    this.popperInstance = null
+    return true;
+  }
+
+  destroyPopperInstance = (callback: () => void) => {
+    if (this.destroy()) this.forceUpdate(callback)
+
   };
 
   updatePopperInstance = () => {
-    if (this.state.popperInstance) {
-      this.destroyPopperInstance(() => this.initPopperInstance());
-    }
+    if (this.destroy()) this.initPopperInstance();
   };
 
   scheduleUpdate = () => {
-    if (this.state.popperInstance) {
-      this.state.popperInstance.scheduleUpdate();
+    if (this.popperInstance) {
+      this.popperInstance.scheduleUpdate();
     }
   };
 
@@ -184,9 +186,7 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
   }
 
   componentWillUnmount() {
-    if (this.state.popperInstance) {
-      this.state.popperInstance.destroy();
-    }
+    this.destroy()
   }
 
   render() {

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -32,7 +32,6 @@ export type PopperChildren = PopperChildrenProps => React.Node;
 
 export type PopperProps = {
   children: PopperChildren,
-  init?: boolean,
   eventsEnabled?: boolean,
   innerRef?: getRefFn,
   modifiers?: Modifiers,
@@ -57,7 +56,6 @@ const initialArrowStyle = {};
 
 export class InnerPopper extends React.Component<PopperProps, PopperState> {
   static defaultProps = {
-    init: true,
     placement: 'bottom',
     eventsEnabled: true,
     referenceElement: undefined,
@@ -132,24 +130,20 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
   getOutOfBoundariesState = () =>
     this.state.data ? this.state.data.hide : undefined;
 
-  destroy = () => {
-    if (!this.popperInstance) return false;
+  destroyPopperInstance = () => {
+    if (!this.popperInstance) return;
+
     this.popperInstance.destroy();
     this.popperInstance = null;
-    return true;
-  };
-
-  destroyPopperInstance = (callback: () => void) => {
-    if (this.destroy()) this.forceUpdate(callback);
   };
 
   updatePopperInstance = () => {
-    this.destroy();
+    this.destroyPopperInstance();
 
     const { popperNode } = this;
-    const { referenceElement, init } = this.props;
+    const { referenceElement } = this.props;
 
-    if (!referenceElement || !popperNode || !init) return;
+    if (!referenceElement || !popperNode) return;
 
     this.popperInstance = new PopperJS(
       referenceElement,
@@ -167,7 +161,6 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
   componentDidUpdate(prevProps: PopperProps) {
     // If the Popper.js options have changed, update the instance (destroy + create)
     if (
-      this.props.init !== prevProps.init ||
       this.props.placement !== prevProps.placement ||
       this.props.eventsEnabled !== prevProps.eventsEnabled ||
       this.props.referenceElement !== prevProps.referenceElement ||
@@ -178,7 +171,7 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
   }
 
   componentWillUnmount() {
-    this.destroy();
+    this.destroyPopperInstance();
   }
 
   render() {

--- a/src/Popper.test.js
+++ b/src/Popper.test.js
@@ -65,6 +65,19 @@ describe("Popper component", () => {
     expect(instance.state.isDestroyed).toBe(true);
   });
 
+  it.only("handles changing refs gracefully", () => {
+    const referenceElement = document.createElement("div");
+    expect(() => mount(
+      <InnerPopper referenceElemen={referenceElement}>
+        {({ ref, style, placement, arrowProps }) => (
+          <div ref={current => ref(current)} style={style} data-placement={placement}>
+            <div {...arrowProps} ref={current => arrowProps.ref(current)} />
+          </div>
+        )}
+      </InnerPopper>
+    )).not.toThrow();
+  });
+
   it("accepts a `referenceElement` property", () => {
     class VirtualReference {
       getBoundingClientRect() {

--- a/src/Popper.test.js
+++ b/src/Popper.test.js
@@ -1,9 +1,9 @@
 // @flow
-import React from "react";
-import { mount } from "enzyme";
+import React from 'react';
+import { mount } from 'enzyme';
 
 // Private API
-import { InnerPopper } from "./Popper";
+import { InnerPopper } from './Popper';
 
 const mountPopper = props =>
   mount(
@@ -16,71 +16,87 @@ const mountPopper = props =>
     </InnerPopper>
   );
 
-describe("Popper component", () => {
-  it("renders the expected markup", () => {
-    const referenceElement = document.createElement("div");
+describe('Popper component', () => {
+  it('renders the expected markup', () => {
+    const referenceElement = document.createElement('div');
     const wrapper = mountPopper({ referenceElement });
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("initializes the Popper.js instance on first update", () => {
-    const referenceElement = document.createElement("div");
+  it('initializes the Popper.js instance on first update', () => {
+    const referenceElement = document.createElement('div');
     const wrapper = mountPopper({ referenceElement });
     expect(wrapper.instance().popperInstance).toBeDefined();
   });
 
+  it('defers initialization until init is set', () => {
+    const referenceElement = document.createElement('div');
+    const wrapper = mountPopper({ referenceElement, init: false });
+    expect(wrapper.instance().popperInstance).not.toBeDefined();
+
+    wrapper.setProps({ init: 'true' });
+
+    expect(wrapper.instance().popperInstance).toBeDefined();
+  });
+
   it("doesn't update Popper.js instance on props update if not needed by Popper.js", () => {
-    const referenceElement = document.createElement("div");
-    const wrapper = mountPopper({ referenceElement, placement: "bottom" });
+    const referenceElement = document.createElement('div');
+    const wrapper = mountPopper({ referenceElement, placement: 'bottom' });
     const instance = wrapper.instance().popperInstance;
 
     expect(instance).toBeDefined();
 
-    wrapper.setProps({ placement: "bottom" });
+    wrapper.setProps({ placement: 'bottom' });
 
     expect(wrapper.instance().popperInstance).toBe(instance);
   });
 
-  it.only("updates Popper.js on explicitly listed props change", () => {
-    const referenceElement = document.createElement("div");
+  it('updates Popper.js on explicitly listed props change', () => {
+    const referenceElement = document.createElement('div');
     const wrapper = mountPopper({ referenceElement });
     const instance = wrapper.instance().popperInstance;
-    wrapper.setProps({ placement: "top" });
+    wrapper.setProps({ placement: 'top' });
     wrapper.update();
     expect(wrapper.instance().popperInstance).not.toBe(instance);
   });
 
-  it("does not update Popper.js on generic props change", () => {
-    const referenceElement = document.createElement("div");
+  it('does not update Popper.js on generic props change', () => {
+    const referenceElement = document.createElement('div');
     const wrapper = mountPopper({ referenceElement });
     const instance = wrapper.instance().popperInstance;
-    wrapper.setProps({ foo: "bar" });
+    wrapper.setProps({ foo: 'bar' });
     wrapper.update();
     expect(wrapper.instance().popperInstance).toBe(instance);
   });
 
-  it("destroys Popper.js instance on unmount", () => {
-    const referenceElement = document.createElement("div");
+  it('destroys Popper.js instance on unmount', () => {
+    const referenceElement = document.createElement('div');
     const wrapper = mountPopper({ referenceElement });
     const instance = wrapper.instance().popperInstance;
     wrapper.unmount();
     expect(instance.state.isDestroyed).toBe(true);
   });
 
-  it("handles changing refs gracefully", () => {
-    const referenceElement = document.createElement("div");
-    expect(() => mount(
-      <InnerPopper referenceElemen={referenceElement}>
-        {({ ref, style, placement, arrowProps }) => (
-          <div ref={current => ref(current)} style={style} data-placement={placement}>
-            <div {...arrowProps} ref={current => arrowProps.ref(current)} />
-          </div>
-        )}
-      </InnerPopper>
-    )).not.toThrow();
+  it('handles changing refs gracefully', () => {
+    const referenceElement = document.createElement('div');
+    expect(() =>
+      mount(
+        <InnerPopper referenceElemen={referenceElement}>
+          {({ ref, style, placement, arrowProps }) => (
+            <div
+              ref={current => ref(current)}
+              style={style}
+              data-placement={placement}
+            >
+              <div {...arrowProps} ref={current => arrowProps.ref(current)} />
+            </div>
+          )}
+        </InnerPopper>
+      )
+    ).not.toThrow();
   });
 
-  it("accepts a `referenceElement` property", () => {
+  it('accepts a `referenceElement` property', () => {
     class VirtualReference {
       getBoundingClientRect() {
         return {

--- a/src/Popper.test.js
+++ b/src/Popper.test.js
@@ -26,46 +26,48 @@ describe("Popper component", () => {
   it("initializes the Popper.js instance on first update", () => {
     const referenceElement = document.createElement("div");
     const wrapper = mountPopper({ referenceElement });
-    expect(wrapper.state("popperInstance")).toBeDefined();
+    expect(wrapper.instance().popperInstance).toBeDefined();
   });
 
   it("doesn't update Popper.js instance on props update if not needed by Popper.js", () => {
     const referenceElement = document.createElement("div");
     const wrapper = mountPopper({ referenceElement, placement: "bottom" });
-    const instance = wrapper.state("popperInstance");
+    const instance = wrapper.instance().popperInstance;
+
+    expect(instance).toBeDefined();
 
     wrapper.setProps({ placement: "bottom" });
 
-    expect(wrapper.state("popperInstance")).toBe(instance);
+    expect(wrapper.instance().popperInstance).toBe(instance);
   });
 
-  it("updates Popper.js on explicitly listed props change", () => {
+  it.only("updates Popper.js on explicitly listed props change", () => {
     const referenceElement = document.createElement("div");
     const wrapper = mountPopper({ referenceElement });
-    const instance = wrapper.state("popperInstance");
+    const instance = wrapper.instance().popperInstance;
     wrapper.setProps({ placement: "top" });
     wrapper.update();
-    expect(wrapper.state("popperInstance")).not.toBe(instance);
+    expect(wrapper.instance().popperInstance).not.toBe(instance);
   });
 
   it("does not update Popper.js on generic props change", () => {
     const referenceElement = document.createElement("div");
     const wrapper = mountPopper({ referenceElement });
-    const instance = wrapper.state("popperInstance");
+    const instance = wrapper.instance().popperInstance;
     wrapper.setProps({ foo: "bar" });
     wrapper.update();
-    expect(wrapper.state("popperInstance")).toBe(instance);
+    expect(wrapper.instance().popperInstance).toBe(instance);
   });
 
   it("destroys Popper.js instance on unmount", () => {
     const referenceElement = document.createElement("div");
     const wrapper = mountPopper({ referenceElement });
-    const instance = wrapper.state("popperInstance");
+    const instance = wrapper.instance().popperInstance;
     wrapper.unmount();
     expect(instance.state.isDestroyed).toBe(true);
   });
 
-  it.only("handles changing refs gracefully", () => {
+  it("handles changing refs gracefully", () => {
     const referenceElement = document.createElement("div");
     expect(() => mount(
       <InnerPopper referenceElemen={referenceElement}>
@@ -103,7 +105,7 @@ describe("Popper component", () => {
     const virtualReferenceElement = new VirtualReference();
     const wrapper = mountPopper({ referenceElement: virtualReferenceElement });
 
-    expect(wrapper.state("popperInstance").reference).toBe(
+    expect(wrapper.instance().popperInstance.reference).toBe(
       virtualReferenceElement
     );
   });

--- a/src/Popper.test.js
+++ b/src/Popper.test.js
@@ -29,16 +29,6 @@ describe('Popper component', () => {
     expect(wrapper.instance().popperInstance).toBeDefined();
   });
 
-  it('defers initialization until init is set', () => {
-    const referenceElement = document.createElement('div');
-    const wrapper = mountPopper({ referenceElement, init: false });
-    expect(wrapper.instance().popperInstance).not.toBeDefined();
-
-    wrapper.setProps({ init: 'true' });
-
-    expect(wrapper.instance().popperInstance).toBeDefined();
-  });
-
   it("doesn't update Popper.js instance on props update if not needed by Popper.js", () => {
     const referenceElement = document.createElement('div');
     const wrapper = mountPopper({ referenceElement, placement: 'bottom' });

--- a/src/__snapshots__/Popper.test.js.snap
+++ b/src/__snapshots__/Popper.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Popper component renders the expected markup 1`] = `
 <InnerPopper
   eventsEnabled={true}
-  init={true}
   placement="bottom"
   positionFixed={false}
   referenceElement={<div />}

--- a/src/__snapshots__/Popper.test.js.snap
+++ b/src/__snapshots__/Popper.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Popper component renders the expected markup 1`] = `
 <InnerPopper
   eventsEnabled={true}
+  init={true}
   placement="bottom"
   positionFixed={false}
   referenceElement={<div />}


### PR DESCRIPTION
This was originally meant to try and make it harder to hit the infinite loop with refs, but ended up with a small perf improvement by reducing the need to rerender when `popper` and `arrow` nodes are set. We don't actually need to update any children until _after_ the node updates have made their way back into popper, at which point the modifier will update state and re-render with the new styles