### PR TITLE
doc: remove @next + clarify use

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@
 
 React wrapper around [Popper.js](https://popper.js.org).
 
+**important note:** popper.js is **not** a tooltip library, it's a *positioning engine* to be used to build features such as (but not restricted to) tooltips.
+
 ## Install
 
 Via package managers:
 
 ```bash
-npm install react-popper@next --save
+npm install react-popper --save
 # or
-yarn add react-popper@next
+yarn add react-popper
 ```
 
 Via `script` tag (UMD library exposed as `ReactPopper`):


### PR DESCRIPTION
fixes #202 and #209 

About the warning: I'm happy to change the phrasing. Also, if you could create a wiki page linking to tooltips libs and a page listing libs using popper, we could link to those pages. (I have no rights to create wiki pages)