### PR TITLE
Always recreate popper instance when popperNode changes

### DIFF
--- a/src/Popper.js
+++ b/src/Popper.js
@@ -79,7 +79,7 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
     safeInvoke(this.props.innerRef, popperNode);
     this.popperNode = popperNode;
 
-    if (!this.popperInstance) this.updatePopperInstance();
+    this.updatePopperInstance();
   };
 
   setArrowNode = (arrowNode: ?HTMLElement) => {


### PR DESCRIPTION
In our codebase there's a subset of tooltips that do not work properly. Their tooltips work correctly on the first hover but on subsequent hovers only appear after you move your mouse over the element and then away from it.

After some debugging I traced the problem to the `!this.popperNode` condition inside `getPopperStyle()`; replacing it with `false` made the tooltip appear properly on all hovers. That does not seem like a proper fix, however, so I figured updating popper instance every time after popperNode updates would work, and that it does. 

As far as I understand this change results in correct behavior, since Popper instance stores a reference to the popperNode and if the node updates, so should the instance?