### PR TITLE
Expose "update" method from PopperJS

### DIFF
--- a/src/Popper.js
+++ b/src/Popper.js
@@ -25,6 +25,7 @@ export type PopperChildrenProps = {|
   style: StyleOffsets & StylePosition & Style,
   placement: Placement,
   outOfBoundaries: ?boolean,
+  update: () => void,
   scheduleUpdate: () => void,
   arrowProps: PopperArrowProps,
 |};
@@ -158,6 +159,12 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
     );
   };
 
+  update = () => {
+    if (this.popperInstance) {
+      this.popperInstance.update();
+    }
+  };
+
   scheduleUpdate = () => {
     if (this.popperInstance) {
       this.popperInstance.scheduleUpdate();
@@ -200,6 +207,7 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
       style: this.getPopperStyle(),
       placement: this.getPopperPlacement(),
       outOfBoundaries: this.getOutOfBoundariesState(),
+      update: this.update,
       scheduleUpdate: this.scheduleUpdate,
       arrowProps: {
         ref: this.setArrowNode,

--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -28,6 +28,7 @@ interface PopperChildrenProps {
   outOfBoundaries: boolean | null;
   placement: PopperJS.Placement;
   ref: RefHandler;
+  update: () => void;
   scheduleUpdate: () => void;
   style: React.CSSProperties;
 }


### PR DESCRIPTION
Right now only the `scheduleUpdate` method is exposed.
This makes it difficult to build frame-perfect behaviors that rely on Popper updating.