### PR TITLE
export defaults from popperJS

### DIFF
--- a/src/Popper.js
+++ b/src/Popper.js
@@ -209,8 +209,8 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
   }
 }
 
-const placements = PopperJS.placements;
-export { placements };
+const { placements, Defaults } = PopperJS;
+export { placements, Defaults };
 
 export default function Popper(props: PopperProps) {
   return (

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -209,8 +209,8 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
   }
 }
 
-const { placements, Defaults } = PopperJS;
-export { placements, Defaults };
+const { placements } = PopperJS;
+export { placements, PopperJS };
 
 export default function Popper(props: PopperProps) {
   return (

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 // @flow
 
 // Public components
-import Popper, { placements, Defaults as PopperJSDefaults } from './Popper';
+import Popper, { placements, PopperJS } from './Popper';
 import Manager from './Manager';
 import Reference from './Reference';
-export { Popper, placements, Manager, Reference, PopperJSDefaults };
+export { Popper, placements, Manager, Reference, PopperJS };
 
 // Public types
 import type { Placement } from 'popper.js';

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 // @flow
 
 // Public components
-import Popper, { placements } from './Popper';
+import Popper, { placements, Defaults as PopperJSDefaults } from './Popper';
 import Manager from './Manager';
 import Reference from './Reference';
-export { Popper, placements, Manager, Reference };
+export { Popper, placements, Manager, Reference, PopperJSDefaults };
 
 // Public types
 import type { Placement } from 'popper.js';


### PR DESCRIPTION
Why?

in my app i need to look at popperJS default values in order to pass down props to <Popper> component.

To do so, i have to add a reference to popperJS library in my project that pulls in a copy of popperJS other than the one that is imported from react-popper ( probably because it is not the exact same version )

Since <Popper> takes a prop of type modifiers, and those modifiers are a complex object stored in popperJS.Defaults, is comfortable to have the default value for that object at hand.

Unless i m missing a better way to get them from react-popper