### PR TITLE
Allow custom arrow modifier

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/index.umd.js": {
-    "bundled": 49514,
-    "minified": 17648,
-    "gzipped": 5674
+    "bundled": 49411,
+    "minified": 17642,
+    "gzipped": 5583
   },
   "dist/index.umd.min.js": {
-    "bundled": 25173,
-    "minified": 10015,
-    "gzipped": 3378
+    "bundled": 24106,
+    "minified": 9863,
+    "gzipped": 3275
   },
   "dist/index.esm.js": {
-    "bundled": 9538,
-    "minified": 5425,
-    "gzipped": 1716,
+    "bundled": 9726,
+    "minified": 5598,
+    "gzipped": 1758,
     "treeshaked": {
       "rollup": {
-        "code": 4471,
+        "code": 4635,
         "import_statements": 137
       },
       "webpack": {
-        "code": 5205
+        "code": 5756
       }
     }
   }

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -109,6 +109,7 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
     modifiers: {
       ...this.props.modifiers,
       arrow: {
+        ...(this.props.modifiers && this.props.modifiers.arrow),
         enabled: !!this.arrowNode,
         element: this.arrowNode,
       },


### PR DESCRIPTION
I updated `react-popper` in my project from `0.x` to latest `1.x` and found that I can't set custom `fn` for `arrow` modifier.

This PR will fix it ;-)