### PR TITLE
More explicit referenceElement setting on Popper.js

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/index.umd.js": {
-    "bundled": 49411,
-    "minified": 17642,
-    "gzipped": 5583
+    "bundled": 49703,
+    "minified": 17814,
+    "gzipped": 5717
   },
   "dist/index.umd.min.js": {
-    "bundled": 24106,
-    "minified": 9863,
-    "gzipped": 3275
+    "bundled": 25362,
+    "minified": 10181,
+    "gzipped": 3420
   },
   "dist/index.esm.js": {
-    "bundled": 9726,
-    "minified": 5598,
-    "gzipped": 1758,
+    "bundled": 9794,
+    "minified": 5639,
+    "gzipped": 1769,
     "treeshaked": {
       "rollup": {
-        "code": 4635,
+        "code": 4637,
         "import_statements": 137
       },
       "webpack": {
-        "code": 5756
+        "code": 5371
       }
     }
   }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 React Popper authors
+Copyright (c) 2018 React Popper authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-popper",
-  "version": "1.0.2",
+  "version": "1.3.0",
   "description": "React wrapper around Popper.js",
   "license": "MIT",
   "author": "Travis Arnold <travis@souporserious.com> (http://souporserious.com)",
@@ -58,6 +58,7 @@
     "react": "0.14.x || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "@types/react": "^16.1.0",
     "babel-runtime": "6.x.x",
     "create-react-context": "^0.2.1",
     "popper.js": "^1.14.4",

--- a/src/Manager.test.js
+++ b/src/Manager.test.js
@@ -3,7 +3,9 @@ import React from "react";
 import { mount } from "enzyme";
 
 // Public API
-import { Manager } from ".";
+import { Manager, Popper, Reference } from ".";
+
+import { InnerPopper } from './Popper';
 
 // Private API
 import { ManagerContext } from "./Manager";
@@ -41,6 +43,55 @@ describe("Manager component", () => {
     expect(wrapper.find(Reference).prop("referenceNode")).toBe(referenceNode);
   });
 });
+
+describe('Managed Reference', () => {
+  it('If passed a referenceElement prop value, uses the referenceElement prop value', () => {
+    const element = document.createElement("div");
+    const wrapper = mount(
+      <Manager>
+        <Reference>
+          {({ ref }) => (
+            <div ref={ref}>
+              hello
+            </div>
+          )}
+        </Reference>
+        <Popper referenceElement={element}>
+          {() => null}
+        </Popper>
+      </Manager>
+    );
+    const PopperInstance = wrapper.find(InnerPopper);
+    expect(PopperInstance.prop('referenceElement')).toBe(element);
+  });
+  it('If the referenceElement prop is undefined, use the referenceNode from context', () => {
+    let referenceElement;
+    let ReferenceComp = ({ innerRef }) => (
+      <div ref={(node) => {
+        // We just want to invoke this once so that we have access to the referenceElement in the upper scope.
+        if (referenceElement) return;
+        innerRef(node);
+        referenceElement = node;
+      }}>
+        hello
+      </div>
+    );
+    const wrapper = mount(
+      <Manager>
+        <Reference>
+          {({ ref }) => (
+             <ReferenceComp innerRef={ref}/>
+          )}
+        </Reference>
+        <Popper referenceElement={undefined}>
+          {() => null}
+        </Popper>
+      </Manager>
+    );
+    const PopperInstance = wrapper.find(InnerPopper);
+    expect(PopperInstance.prop('referenceElement')).toBe(referenceElement);
+  })
+})
 
 describe("ReferenceNodeContext", () => {
   it("provides proper default values", () => {

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -213,11 +213,14 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
 const placements = PopperJS.placements;
 export { placements };
 
-export default function Popper(props: PopperProps) {
+export default function Popper({ referenceElement, ...props }: PopperProps) {
   return (
     <ManagerContext.Consumer>
       {({ referenceNode }) => (
-        <InnerPopper referenceElement={referenceNode} {...props} />
+        <InnerPopper
+          referenceElement={referenceElement ? referenceElement : referenceNode}
+          {...props}
+        />
       )}
     </ManagerContext.Consumer>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,7 +1267,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:


### PR DESCRIPTION
Hello, first and foremost thank you so much for this library! 
This is a small non-intrusive change to how prop.referenceElement and referenceNode passed through context currently interact within the Popper.js file. 

For context, within atlassian we currently have a component that's a thin wrapper around react-popper that enforces certain internal configuration opinions. This wrapper supports both using the Reference component to instantiate a referenceNode in context; as well as the referenceElement prop of the Popper component. At the moment declaring a default value of undefined on the referenceElement prop overrides the referenceNode that may be available through context. This seems like an unintended side effect of prop spreading. 

This is a small change to ensure that if referenceElement is not defined, we always fallback to the referenceNode in context. Added two quick tests to assert this. 

Thanks again for the lib! 