### PR TITLE
Allow warning 4.0

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,11 +1,11 @@
 {
   "dist/index.umd.js": {
-    "bundled": 49411,
-    "minified": 17642,
-    "gzipped": 5583
+    "bundled": 49355,
+    "minified": 17594,
+    "gzipped": 5513
   },
   "dist/index.umd.min.js": {
-    "bundled": 24106,
+    "bundled": 23982,
     "minified": 9863,
     "gzipped": 3275
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "popper.js": "^1.14.4",
     "prop-types": "^15.6.1",
     "typed-styles": "^0.0.5",
-    "warning": "^3.0.0"
+    "warning": ">=3.0.0 <5.0.0"
   },
   "devDependencies": {
     "@types/react": "^16.1.0",


### PR DESCRIPTION
This version is still API compatible. The breaking changes were a license change and internal changes.

Closes GH-226