### PR TITLE
refactor: getReferenceRef -> setReferenceNode to avoid confusion

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -1,34 +1,37 @@
 // @flow
-import * as React from "react";
-import createContext, { type Context } from "create-react-context";
+import * as React from 'react';
+import createContext, { type Context } from 'create-react-context';
 
 export const ManagerContext: Context<{
-  getReferenceRef?: (?HTMLElement) => void,
+  setReferenceNode?: (?HTMLElement) => void,
   referenceNode?: ?HTMLElement,
-}> = createContext({ getReferenceRef: undefined, referenceNode: undefined });
+}> = createContext({ setReferenceNode: undefined, referenceNode: undefined });
 
 export type ManagerProps = {
   children: React.Node,
 };
 type ManagerState = {
   context: {
-    getReferenceRef?: (?HTMLElement) => void,
+    setReferenceNode?: (?HTMLElement) => void,
     referenceNode?: ?HTMLElement,
   },
 };
 
-export default class Manager extends React.Component<ManagerProps, ManagerState> {
+export default class Manager extends React.Component<
+  ManagerProps,
+  ManagerState
+> {
   constructor() {
     super();
     this.state = {
       context: {
-        getReferenceRef: this.getReferenceRef,
+        setReferenceNode: this.setReferenceNode,
         referenceNode: undefined,
       },
     };
   }
 
-  getReferenceRef = (referenceNode: ?HTMLElement) =>
+  setReferenceNode = (referenceNode: ?HTMLElement) =>
     this.setState(({ context }) => ({
       context: { ...context, referenceNode },
     }));

--- a/src/Manager.test.js
+++ b/src/Manager.test.js
@@ -1,17 +1,17 @@
 // @flow
-import React from "react";
-import { mount } from "enzyme";
+import React from 'react';
+import { mount } from 'enzyme';
 
 // Public API
-import { Manager, Popper, Reference } from ".";
+import { Manager, Popper, Reference } from '.';
 
 import { InnerPopper } from './Popper';
 
 // Private API
-import { ManagerContext } from "./Manager";
+import { ManagerContext } from './Manager';
 
-describe("Manager component", () => {
-  it("renders the expected markup", () => {
+describe('Manager component', () => {
+  it('renders the expected markup', () => {
     const wrapper = mount(
       <Manager>
         <div id="reference" />
@@ -21,16 +21,16 @@ describe("Manager component", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("provides the related context", () => {
+  it('provides the related context', () => {
     const Reference = () => null;
-    const referenceNode = document.createElement("div");
+    const referenceNode = document.createElement('div');
 
     const wrapper = mount(
       <Manager>
         <ManagerContext.Consumer>
-          {({ getReferenceRef, referenceNode }) => (
+          {({ setReferenceNode, referenceNode }) => (
             <Reference
-              getReferenceRef={getReferenceRef}
+              setReferenceNode={setReferenceNode}
               referenceNode={referenceNode}
             />
           )}
@@ -38,27 +38,19 @@ describe("Manager component", () => {
       </Manager>
     );
 
-    wrapper.find(Reference).prop("getReferenceRef")(referenceNode);
+    wrapper.find(Reference).prop('setReferenceNode')(referenceNode);
     wrapper.update();
-    expect(wrapper.find(Reference).prop("referenceNode")).toBe(referenceNode);
+    expect(wrapper.find(Reference).prop('referenceNode')).toBe(referenceNode);
   });
 });
 
 describe('Managed Reference', () => {
   it('If passed a referenceElement prop value, uses the referenceElement prop value', () => {
-    const element = document.createElement("div");
+    const element = document.createElement('div');
     const wrapper = mount(
       <Manager>
-        <Reference>
-          {({ ref }) => (
-            <div ref={ref}>
-              hello
-            </div>
-          )}
-        </Reference>
-        <Popper referenceElement={element}>
-          {() => null}
-        </Popper>
+        <Reference>{({ ref }) => <div ref={ref}>hello</div>}</Reference>
+        <Popper referenceElement={element}>{() => null}</Popper>
       </Manager>
     );
     const PopperInstance = wrapper.find(InnerPopper);
@@ -67,41 +59,37 @@ describe('Managed Reference', () => {
   it('If the referenceElement prop is undefined, use the referenceNode from context', () => {
     let referenceElement;
     let ReferenceComp = ({ innerRef }) => (
-      <div ref={(node) => {
-        // We just want to invoke this once so that we have access to the referenceElement in the upper scope.
-        if (referenceElement) return;
-        innerRef(node);
-        referenceElement = node;
-      }}>
+      <div
+        ref={node => {
+          // We just want to invoke this once so that we have access to the referenceElement in the upper scope.
+          if (referenceElement) return;
+          innerRef(node);
+          referenceElement = node;
+        }}
+      >
         hello
       </div>
     );
     const wrapper = mount(
       <Manager>
-        <Reference>
-          {({ ref }) => (
-             <ReferenceComp innerRef={ref}/>
-          )}
-        </Reference>
-        <Popper referenceElement={undefined}>
-          {() => null}
-        </Popper>
+        <Reference>{({ ref }) => <ReferenceComp innerRef={ref} />}</Reference>
+        <Popper referenceElement={undefined}>{() => null}</Popper>
       </Manager>
     );
     const PopperInstance = wrapper.find(InnerPopper);
     expect(PopperInstance.prop('referenceElement')).toBe(referenceElement);
-  })
-})
+  });
+});
 
-describe("ReferenceNodeContext", () => {
-  it("provides proper default values", () => {
+describe('ReferenceNodeContext', () => {
+  it('provides proper default values', () => {
     const Reference = () => null;
     const wrapper = mount(
       <div>
         <ManagerContext.Consumer>
-          {({ getReferenceRef, referenceNode }) => (
+          {({ setReferenceNode, referenceNode }) => (
             <Reference
-              getReferenceRef={getReferenceRef}
+              setReferenceNode={setReferenceNode}
               referenceNode={referenceNode}
             />
           )}
@@ -109,6 +97,6 @@ describe("ReferenceNodeContext", () => {
       </div>
     );
 
-    expect(wrapper.find(Reference).prop("getReferenceRef")).toBeUndefined();
+    expect(wrapper.find(Reference).prop('setReferenceNode')).toBeUndefined();
   });
 });

--- a/src/Reference.js
+++ b/src/Reference.js
@@ -11,18 +11,20 @@ export type ReferenceProps = {
 };
 
 type InnerReferenceProps = {
-  getReferenceRef?: (?HTMLElement) => void,
-}
+  setReferenceNode?: (?HTMLElement) => void,
+};
 
-class InnerReference extends React.Component<ReferenceProps & InnerReferenceProps> {
+class InnerReference extends React.Component<
+  ReferenceProps & InnerReferenceProps
+> {
   refHandler = (node: ?HTMLElement) => {
     safeInvoke(this.props.innerRef, node);
-    safeInvoke(this.props.getReferenceRef, node);
-  }
+    safeInvoke(this.props.setReferenceNode, node);
+  };
 
   render() {
     warning(
-      this.props.getReferenceRef,
+      this.props.setReferenceNode,
       '`Reference` should not be used outside of a `Manager` component.'
     );
     return unwrapArray(this.props.children)({ ref: this.refHandler });
@@ -32,7 +34,9 @@ class InnerReference extends React.Component<ReferenceProps & InnerReferenceProp
 export default function Reference(props: ReferenceProps) {
   return (
     <ManagerContext.Consumer>
-      {({ getReferenceRef }) => <InnerReference getReferenceRef={getReferenceRef} {...props} />}
+      {({ setReferenceNode }) => (
+        <InnerReference setReferenceNode={setReferenceNode} {...props} />
+      )}
     </ManagerContext.Consumer>
   );
 }

--- a/src/Reference.test.js
+++ b/src/Reference.test.js
@@ -1,23 +1,23 @@
 // @flow
-import React from "react";
-import { mount } from "enzyme";
+import React from 'react';
+import { mount } from 'enzyme';
 
 // Public API
-import { Reference } from ".";
+import { Reference } from '.';
 
 // Private API
-import { ManagerContext } from "./Manager";
+import { ManagerContext } from './Manager';
 
-describe("Arrow component", () => {
-  it("renders the expected markup", () => {
-    const getReferenceRef = jest.fn();
+describe('Arrow component', () => {
+  it('renders the expected markup', () => {
+    const setReferenceNode = jest.fn();
 
     // HACK: wrapping DIV needed to make Enzyme happy for now
     const wrapper = mount(
       <div>
         <ManagerContext.Provider
           value={{
-            getReferenceRef,
+            setReferenceNode,
             referenceNode: undefined,
           }}
         >
@@ -28,15 +28,15 @@ describe("Arrow component", () => {
     expect(wrapper.children()).toMatchSnapshot();
   });
 
-  it("consumes the ManagerContext from Manager", () => {
-    const getReferenceRef = jest.fn();
+  it('consumes the ManagerContext from Manager', () => {
+    const setReferenceNode = jest.fn();
 
     // HACK: wrapping DIV needed to make Enzyme happy for now
     mount(
       <div>
         <ManagerContext.Provider
           value={{
-            getReferenceRef,
+            setReferenceNode,
             referenceNode: undefined,
           }}
         >
@@ -44,6 +44,6 @@ describe("Arrow component", () => {
         </ManagerContext.Provider>
       </div>
     );
-    expect(getReferenceRef).toHaveBeenCalled();
+    expect(setReferenceNode).toHaveBeenCalled();
   });
 });

--- a/src/__snapshots__/Manager.test.js.snap
+++ b/src/__snapshots__/Manager.test.js.snap
@@ -5,8 +5,8 @@ exports[`Manager component renders the expected markup 1`] = `
   <Provider
     value={
       Object {
-        "getReferenceRef": [Function],
         "referenceNode": undefined,
+        "setReferenceNode": [Function],
       }
     }
   >

--- a/src/__snapshots__/Reference.test.js.snap
+++ b/src/__snapshots__/Reference.test.js.snap
@@ -4,21 +4,21 @@ exports[`Arrow component renders the expected markup 1`] = `
 <Provider
   value={
     Object {
-      "getReferenceRef": [MockFunction] {
+      "referenceNode": undefined,
+      "setReferenceNode": [MockFunction] {
         "calls": Array [
           Array [
             <div />,
           ],
         ],
       },
-      "referenceNode": undefined,
     }
   }
 >
   <Reference>
     <Consumer>
       <InnerReference
-        getReferenceRef={
+        setReferenceNode={
           [MockFunction] {
             "calls": Array [
               Array [


### PR DESCRIPTION
`getReferenceRef` actually set the reference node and return nothing, rename it to `setReferenceNode` to avoid confusion
