### PR TITLE
Fix readme regarding fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const Example = () => (
 `react-popper` makes use of a React pattern called **"render prop"**, if you are not
 familiar with it, please read more [on the official React documentation](https://reactjs.org/docs/render-props.html).
 
-> Using React <=15 or Preact? The components created with them don't support to return
+> Using React <=16 or Preact? The components created with them don't support to return
 [fragments](https://reactjs.org/docs/fragments.html), this means that you will need to
 wrap `<Reference />` and `<Popper />` into a single, common, `<div />` to make `react-popper` work.
 


### PR DESCRIPTION
The readme currently states users with React <=15 must use a wrapping div around the Reference and Popper components. However fragments weren't added to React until v16. This change helps users with React <=16 properly set up the components and avoid the error that branches from it.

Sources
https://reactjs.org/blog/2017/09/26/react-v16.0.html#new-render-return-types-fragments-and-strings