### PR TITLE
perf: Reduce Popper updates when placement don't change

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/index.umd.js": {
-    "bundled": 49749,
-    "minified": 17751,
-    "gzipped": 5578
+    "bundled": 49689,
+    "minified": 17716,
+    "gzipped": 5566
   },
   "dist/index.umd.min.js": {
-    "bundled": 24376,
-    "minified": 10020,
-    "gzipped": 3347
+    "bundled": 24316,
+    "minified": 9985,
+    "gzipped": 3336
   },
   "dist/index.esm.js": {
-    "bundled": 10105,
-    "minified": 5808,
-    "gzipped": 1838,
+    "bundled": 10045,
+    "minified": 5773,
+    "gzipped": 1827,
     "treeshaked": {
       "rollup": {
-        "code": 4604,
+        "code": 4569,
         "import_statements": 137
       },
       "webpack": {
-        "code": 5725
+        "code": 5690
       }
     }
   }

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -65,7 +65,7 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
 
   state = {
     data: undefined,
-    placement: undefined,
+    placement: this.props.placement,
   };
 
   popperInstance: ?Instance;
@@ -91,10 +91,7 @@ export class InnerPopper extends React.Component<PopperProps, PopperState> {
     order: 900,
     fn: (data: Object) => {
       const { placement } = data;
-      this.setState(
-        { data, placement },
-        placement !== this.state.placement ? this.scheduleUpdate : undefined
-      );
+      this.setState({ data, placement });
       return data;
     },
   };

--- a/src/Popper.test.js
+++ b/src/Popper.test.js
@@ -115,4 +115,22 @@ describe('Popper component', () => {
       virtualReferenceElement
     );
   });
+
+  it(`should render 2 times when placement was not updated, 3 times when it was`, () => {
+    const referenceElement = document.createElement('div');
+    let renderCounter = 0;
+    const wrapper = mount(
+      <InnerPopper placement="top" referenceElement={referenceElement}>
+        {({ ref, style, placement }) => {
+          renderCounter++;
+          return <div ref={ref} style={style} data-placement={placement} />;
+        }}
+      </InnerPopper>
+    );
+    expect(renderCounter).toBe(2);
+    renderCounter = 0;
+
+    wrapper.setProps({ placement: 'bottom' });
+    expect(renderCounter).toBe(3);
+  });
 });


### PR DESCRIPTION
ScheduleUpdate is called twice per state change, as `placement !== this.state.placement` is not inside the `setState` callback, so the `this.state` is referring to current state and it's calling `scheduleUpdate` when the callback fires

In the same time in `componentDidUpdate` we have the 
```js
if (prevState.placement !== this.state.placement) {
  this.scheduleUpdate();
}
```
state placement changed, call the `scheduleUpdate`

Outcome of this is that on every new `state.placement` we call `two` time the `scheduleUpdate` IMHO it's redundant as scheduleUpdate is called at the same time.