### PR TITLE
fix: avoid Flow error in call to warning() (#260)

### DIFF
--- a/src/Reference.js
+++ b/src/Reference.js
@@ -24,7 +24,7 @@ class InnerReference extends React.Component<
 
   render() {
     warning(
-      this.props.setReferenceNode,
+      Boolean(this.props.setReferenceNode),
       '`Reference` should not be used outside of a `Manager` component.'
     );
     return unwrapArray(this.props.children)({ ref: this.refHandler });

--- a/src/Reference.test.js
+++ b/src/Reference.test.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import warning from 'warning';
 import { mount } from 'enzyme';
 
 // Public API
@@ -8,7 +9,13 @@ import { Reference } from '.';
 // Private API
 import { ManagerContext } from './Manager';
 
+jest.mock('warning');
+
 describe('Arrow component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders the expected markup', () => {
     const setReferenceNode = jest.fn();
 
@@ -45,5 +52,46 @@ describe('Arrow component', () => {
       </div>
     );
     expect(setReferenceNode).toHaveBeenCalled();
+  });
+
+  it('warns when setReferenceNode is present', () => {
+    const setReferenceNode = jest.fn();
+
+    // HACK: wrapping DIV needed to make Enzyme happy for now
+    mount(
+      <div>
+        <ManagerContext.Provider
+          value={{
+            setReferenceNode,
+            referenceNode: undefined,
+          }}
+        >
+          <Reference>{({ ref }) => <div ref={ref} />}</Reference>
+        </ManagerContext.Provider>
+      </div>
+    );
+    expect(warning).toHaveBeenCalledWith(
+      true,
+      '`Reference` should not be used outside of a `Manager` component.'
+    );
+  });
+
+  it('does not warn when setReferenceNode is not present', () => {
+    // HACK: wrapping DIV needed to make Enzyme happy for now
+    mount(
+      <div>
+        <ManagerContext.Provider
+          value={{
+            referenceNode: undefined,
+          }}
+        >
+          <Reference>{({ ref }) => <div ref={ref} />}</Reference>
+        </ManagerContext.Provider>
+      </div>
+    );
+    expect(warning).toHaveBeenCalledWith(
+      false,
+      '`Reference` should not be used outside of a `Manager` component.'
+    );
   });
 });


### PR DESCRIPTION
#260 

With flow-typed, warning() expects its first argument to be a boolean.
Added tests to ensure warning() is called correctly.