### PR TITLE
Fix update/re-rendering logic

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/index.umd.js": {
-    "bundled": 52221,
-    "minified": 17785,
-    "gzipped": 5683
+    "bundled": 52578,
+    "minified": 18111,
+    "gzipped": 5843
   },
   "dist/index.umd.min.js": {
-    "bundled": 26233,
-    "minified": 10054,
-    "gzipped": 3437
+    "bundled": 26590,
+    "minified": 10380,
+    "gzipped": 3604
   },
   "dist/index.esm.js": {
-    "bundled": 11275,
-    "minified": 6748,
-    "gzipped": 1854,
+    "bundled": 10321,
+    "minified": 6227,
+    "gzipped": 1809,
     "treeshaked": {
       "rollup": {
-        "code": 3718,
-        "import_statements": 137
+        "code": 3413,
+        "import_statements": 168
       },
       "webpack": {
-        "code": 4824
+        "code": 4558
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "create-react-context": "<=0.2.2",
+    "fast-deep-equal": "^2.0.1",
     "popper.js": "^1.14.4",
     "prop-types": "^15.6.1",
     "typed-styles": "^0.0.7",

--- a/src/Popper.test.js
+++ b/src/Popper.test.js
@@ -116,7 +116,7 @@ describe('Popper component', () => {
     );
   });
 
-  it(`should render 3 times when placement is changed`, () => {
+  it(`should render twice when placement is changed`, () => {
     const referenceElement = document.createElement('div');
     let renderCounter = 0;
     const wrapper = mount(
@@ -127,10 +127,10 @@ describe('Popper component', () => {
         }}
       </InnerPopper>
     );
-    expect(renderCounter).toBe(3);
+    expect(renderCounter).toBe(2);
     renderCounter = 0;
 
     wrapper.setProps({ placement: 'bottom' });
-    expect(renderCounter).toBe(3);
+    expect(renderCounter).toBe(2);
   });
 });


### PR DESCRIPTION
Previously, re-rendering a `<Popper />` component manually would not update the Popper instance, as long as the `placement` prop did not change and the render function returned a similar DOM tree (so that `popperNode` remained unchanged). E.g., if the render function returned a larger child, Popper.js would not get a chance to re-position the popper element accordingly.

Fix this by always recreating/updating the Popper instance in `componentDidUpdate`, and being somewhat more clever in the `updateStateModifier()` function (just updating the state and hence re-rendering if something of relevance did actually change).