### PR TITLE
fix: update TypeScript types to allow SVG references

### DIFF
--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -6,7 +6,7 @@ interface ManagerProps {
 }
 export class Manager extends React.Component<ManagerProps, {}> { }
 
-type RefHandler = (ref: HTMLElement | null) => void;
+type RefHandler = (ref: HTMLElement | SVGElement | null) => void;
 
 interface ReferenceChildrenProps {
   ref: RefHandler;

--- a/typings/tests/svg-test.tsx
+++ b/typings/tests/svg-test.tsx
@@ -1,0 +1,44 @@
+// Please remember to update also the Flow test files that can
+// be found under `/src/__typings__` please. Thanks! 🤗
+
+import * as React from 'react';
+import { Manager, Reference, Popper } from '../..';
+
+export const Test = () => (
+  <Manager>
+    <svg>
+      <Reference>{({ ref }) => <g ref={ref} />}</Reference>
+    </svg>
+    <Popper
+      eventsEnabled
+      positionFixed
+      modifiers={{ flip: { enabled: false } }}
+    >
+      {({
+        ref,
+        style,
+        placement,
+        outOfBoundaries,
+        scheduleUpdate,
+        arrowProps,
+      }) => (
+        <div
+          ref={ref}
+          style={{ ...style, opacity: outOfBoundaries ? 0 : 1 }}
+          data-placement={placement}
+          onClick={() => scheduleUpdate()}
+        >
+          Popper
+          <div ref={arrowProps.ref} style={arrowProps.style} />
+        </div>
+      )}
+    </Popper>
+    <Popper>
+      {({ ref, style, placement }) => (
+        <div ref={ref} style={style} data-placement={placement}>
+          Popper
+        </div>
+      )}
+    </Popper>
+  </Manager>
+);


### PR DESCRIPTION
Re https://github.com/FezVrasta/react-popper/issues/277

Apologies to @paolostyle for scooping your PR if you still wanted to make it :sweat_smile: 