### PR TITLE
Export PopperChildrenProps and PopperArrowProps

### DIFF
--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -18,12 +18,12 @@ interface ReferenceProps {
 }
 export class Reference extends React.Component<ReferenceProps, {}> { }
 
-interface PopperArrowProps {
+export interface PopperArrowProps {
   ref: RefHandler;
   style: React.CSSProperties;
 }
 
-interface PopperChildrenProps {
+export interface PopperChildrenProps {
   arrowProps: PopperArrowProps;
   outOfBoundaries: boolean | null;
   placement: PopperJS.Placement;
@@ -32,7 +32,7 @@ interface PopperChildrenProps {
   style: React.CSSProperties;
 }
 
-interface PopperProps {
+export interface PopperProps {
   children: (props: PopperChildrenProps) => React.ReactNode;
   eventsEnabled?: boolean;
   innerRef?: RefHandler;


### PR DESCRIPTION
Fixes #276 

This makes the TS typings a bit easier to work with when not defining the children inline. I ran into this when using `React.useMemo` on the children, but I'm sure there are other use cases since someone else filed the issue.