### PR TITLE
Set side effects to 'false'

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "typings": "typings/react-popper.d.ts",
+  "sideEffects": false,
   "files": [
     "/dist",
     "/lib",


### PR DESCRIPTION
This sets the `package.json` field `sideEffects` to `false`. This allows for better tree shaking by downstream consumers, see https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free for more information.

I skimmed over all included files and I did not see anything that would count following webpack's definition of tree shaking.